### PR TITLE
Fix double designation exception

### DIFF
--- a/Source/Quarry/Orders/Designator_ReclaimSoil.cs
+++ b/Source/Quarry/Orders/Designator_ReclaimSoil.cs
@@ -1,4 +1,5 @@
-﻿using RimWorld;
+﻿using System.Collections.Generic;
+using RimWorld;
 using Verse;
 
 namespace Quarry {
@@ -60,6 +61,11 @@ namespace Quarry {
 
 		public override void SelectedUpdate() {
 			GenUI.RenderMouseoverBracket();
+		}
+		
+		public override void RenderHighlight(List<IntVec3> dragCells)
+		{
+			DesignatorUtility.RenderHighlightOverSelectableCells(this, dragCells);
 		}
 	}
 }

--- a/Source/Quarry/Orders/Designator_ReclaimSoil.cs
+++ b/Source/Quarry/Orders/Designator_ReclaimSoil.cs
@@ -27,7 +27,8 @@ namespace Quarry {
 			else if (c.Fogged(Map)) {
 				result = false;
 			}
-			else if (Map.designationManager.DesignationAt(c, QuarryDefOf.QRY_Designator_ReclaimSoil) != null) {
+			else if (Map.designationManager.DesignationAt(c, QuarryDefOf.QRY_Designator_ReclaimSoil) != null || 
+			         Map.designationManager.DesignationAt(c, DesignationDefOf.SmoothFloor) != null) {
 				result = false;
 			}
 			else if (c.InNoBuildEdgeArea(Map)) {

--- a/Source/Quarry/Quarry.csproj
+++ b/Source/Quarry/Quarry.csproj
@@ -31,14 +31,14 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>$(ProgramFiles)\Steam\steamapps\common\RimWorld\RimWorldWin_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\RimWorld\RimWorldWin_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>$(ProgramFiles)\Steam\steamapps\common\RimWorld\RimWorldWin_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>


### PR DESCRIPTION
This patch fixes lots of errors when trying to designate already designated cells.
And shows designation area while dragging.