### PR TITLE
Fix double components at mod configuration screen

### DIFF
--- a/Source/Quarry/Static/QuarryDefOf.cs
+++ b/Source/Quarry/Static/QuarryDefOf.cs
@@ -10,7 +10,7 @@ namespace Quarry
         public static ThingDef QRY_Quarry;
         public static ThingDef QRY_MiniQuarry;
         public static ThingDef Chemfuel;
-        public static ThingDef ComponentIndustrial;
+        public static ThingDef MineableComponentsIndustrial;
 
         public static TerrainDef QRY_QuarriedGround;
         public static TerrainDef QRY_QuarriedGroundWall;

--- a/Source/Quarry/Utils/OreDictionary.cs
+++ b/Source/Quarry/Utils/OreDictionary.cs
@@ -25,7 +25,7 @@ namespace Quarry {
 
 		private static Predicate<ThingDef> validOre = (
 			(ThingDef def) => def.mineable && 
-			def != QuarryDefOf.ComponentIndustrial && 
+			def != QuarryDefOf.MineableComponentsIndustrial &&
 			def.building != null && 
 			def.building.isResourceRock && 
 			def.building.mineableThing != null


### PR DESCRIPTION
Components appear twice at mod configuration screen by default:
![double-components](https://user-images.githubusercontent.com/3430503/54084140-79198c80-4346-11e9-907b-d5cab9c0a45a.png)
